### PR TITLE
7.x fulltext update

### DIFF
--- a/js/bookreader_overrides.js
+++ b/js/bookreader_overrides.js
@@ -4,11 +4,11 @@
  */
 
 (function ($) {
-  IslandoraBookReader.prototype.buildFullTextDiv = function(jFullTextDiv) {
-    jFullTextDiv.find('.BRfloatMeta').height(600);
-    jFullTextDiv.find('.BRfloatMeta').width(600);
+  var buildTextDiv = function(jFulltextDiv) {
+    jFulltextDiv.find('.BRfloatMeta').height(600);
+    jFulltextDiv.find('.BRfloatMeta').width(600);
     if (3 == this.mode) {
-      jFullTextDiv.find('.BRfloatMeta').html('<div>' + Drupal.t('Full text not supported for this view.') + '</div>');
+      jFulltextDiv.find('.BRfloatMeta').html('<div>' + Drupal.t('Full text not supported for this view.') + '</div>');
     }
     else {
       var index = this.currentIndex();
@@ -29,7 +29,7 @@
       }
       $.get(Drupal.settings.vassardora.text_url, request_data,
         function(data) {
-          jFullTextDiv.find('.BRfloatMeta').html(data);
+          jFulltextDiv.find('.BRfloatMeta').html(data);
           $.trim($('.BRfloatMeta').text());
           // Show the related element, when clicked.
           $('li.vassardora_fulltext_link').click(function(eventObject) {
@@ -44,5 +44,11 @@
         }
       );
     }
+  };
+  if (typeof IslandoraDjatokaBookReader !== 'undefined') {
+    IslandoraDjatokaBookReader.prototype.buildFullTextDiv = buildTextDiv;
   }
-})(jQuery)
+  else if (typeof IslandoraIiifBookReader !== 'undefined') {
+    IslandoraIiifBookReader.prototype.buildFullTextDiv = buildTextDiv;
+  }
+})(jQuery);

--- a/js/bookreader_overrides.js
+++ b/js/bookreader_overrides.js
@@ -4,11 +4,11 @@
  */
 
 (function ($) {
-  var buildTextDiv = function(jFulltextDiv) {
-    jFulltextDiv.find('.BRfloatMeta').height(600);
-    jFulltextDiv.find('.BRfloatMeta').width(600);
+  var buildTextDiv = function(jFullTextDiv) {
+    jFullTextDiv.find('.BRfloatMeta').height(600);
+    jFullTextDiv.find('.BRfloatMeta').width(600);
     if (3 == this.mode) {
-      jFulltextDiv.find('.BRfloatMeta').html('<div>' + Drupal.t('Full text not supported for this view.') + '</div>');
+      jFullTextDiv.find('.BRfloatMeta').html('<div>' + Drupal.t('Full text not supported for this view.') + '</div>');
     }
     else {
       var index = this.currentIndex();
@@ -29,7 +29,7 @@
       }
       $.get(Drupal.settings.vassardora.text_url, request_data,
         function(data) {
-          jFulltextDiv.find('.BRfloatMeta').html(data);
+          jFullTextDiv.find('.BRfloatMeta').html(data);
           $.trim($('.BRfloatMeta').text());
           // Show the related element, when clicked.
           $('li.vassardora_fulltext_link').click(function(eventObject) {


### PR DESCRIPTION
This pull request is in reference to https://support.discoverygarden.ca/a/tickets/9033. It will resolve the issue where german and english translations are not appear when the TEXT button is clicked on the Internet Archive bookreader.

Ticket: https://support.discoverygarden.ca/helpdesk/tickets/9033

-- 
Elkeno Jones
Application Analyst | discoverygarden inc.